### PR TITLE
Update image to use openjdk-11 and pulling upstream prestosql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:11.0.7-jre-slim-buster
 
 # Build arg expected, what version of presto are we building? (Presto's .tar.gz files extract to a versioned folder, we need to know what it's named)
 ARG BUILD_VERSION
@@ -7,20 +7,30 @@ ENV PRESTO_VERSION presto-server-${BUILD_VERSION}
 ENV GOPATH /usr/local/go
 RUN mkdir -p ${GOPATH}
 
-ADD ${PRESTO_VERSION}.tar.gz /opt/presto/
 ADD container_init.sh /container_init.sh
-RUN ln -s /opt/presto/${PRESTO_VERSION} /opt/presto/latest && \
-	chmod +x /container_init.sh && \
-	mkdir -p /opt/presto/conf/catalog && \
-	mkdir -p /var/lib/presto/data && \
-	rm -rf /opt/presto/latest/etc && \
-	ln -s /opt/presto/conf /opt/presto/latest/etc
+RUN apt update && \
+    apt install -y curl && \
+    mkdir -p /opt/presto && \
+    curl -L "https://repo1.maven.org/maven2/io/prestosql/presto-server/${BUILD_VERSION}/${PRESTO_VERSION}.tar.gz" -o "/opt/presto/${PRESTO_VERSION}.tar.gz" && \
+    tar -xzvf "/opt/presto/${PRESTO_VERSION}.tar.gz" -C /opt/presto/ && \
+    ln -s /opt/presto/${PRESTO_VERSION} /opt/presto/latest && \
+    chmod +x /container_init.sh && \
+    mkdir -p /opt/presto/conf/catalog && \
+    mkdir -p /var/lib/presto/data && \
+    rm -rf /opt/presto/latest/etc && \
+    ln -s /opt/presto/conf /opt/presto/latest/etc
 
 #\ && (cd /opt/presto && tar xvf ${PRESTO_VERSION}.tar.gz)
 
 # Fsconsul for making files from consul k/v - use consul 1.0.0 since 'master' is broken somehow in consul's go libs. Fsconsul should use godep/govendor :(
-RUN apt-get update && apt-get install -y golang-go git-core uuid python
-RUN go get -d github.com/Cimpress-MCP/fsconsul && (cd ${GOPATH}/src/github.com/hashicorp/consul && git checkout v1.0.0) && go install github.com/Cimpress-MCP/fsconsul
+RUN apt update && \
+    apt install -y golang-1.11-go git-core uuid python && \
+    ln -s /usr/lib/go-1.11/bin/go /usr/bin/go
+RUN go get -d github.com/Cimpress-MCP/fsconsul && \
+    (cd ${GOPATH}/src/github.com/hashicorp/consul && git checkout v1.0.0) && \
+    go install github.com/Cimpress-MCP/fsconsul && \
+    apt clean all && \
+    rm -rf /var/log/apt/* /var/log/alternatives.log /var/log/bootstrap.log /var/log/dpkg.log
 
 # Run the init script to start fsconsul and presto after
 CMD /container_init.sh

--- a/container_init.sh
+++ b/container_init.sh
@@ -34,10 +34,10 @@ cat > /opt/presto/conf/jvm.config <<EOT
 EOT
 
 # Start fsconsul to generate our catalog configs
-${GOPATH}/bin/fsconsul -addr=${CONSUL_ADDR} -once=true ${CONSUL_PREFIX}/catalog/ /opt/presto/conf/catalog/
+/usr/local/go/bin/fsconsul -addr=${CONSUL_ADDR} -once=true ${CONSUL_PREFIX}/catalog/ /opt/presto/conf/catalog/
 
 # Start fsconsul again to make the node configs
-${GOPATH}/bin/fsconsul -addr=${CONSUL_ADDR} -once=true ${CONSUL_PREFIX}/${PRESTO_ROLE} /opt/presto/conf/
+/usr/local/go/bin/fsconsul -addr=${CONSUL_ADDR} -once=true ${CONSUL_PREFIX}/${PRESTO_ROLE} /opt/presto/conf/
 
 # Now start presto and let it run in the foreground
 /opt/presto/latest/bin/launcher run

--- a/container_init.sh
+++ b/container_init.sh
@@ -2,8 +2,9 @@
 
 # Environment variable defaults
 : ${ENV:=DEV}
-: ${CONSUL_ADDR:=172.17.42.1:8500}
+: ${CONSUL_ADDR:=172.17.0.1:8500}
 : ${CONSUL_PREFIX:=/config/presto}
+# Valid roles are: worker and master
 : ${PRESTO_ROLE:=worker}
 : ${HEAP_PERCENT:=0.5}
 


### PR DESCRIPTION
Newer image is based on multistage docker build old image does not use multi-stage docker process
```
$ docker images
REPOSITORY                                     TAG                                   IMAGE ID            CREATED             SIZE
nxtlytics/presto-docker-consul                 333-test-2                            b19f62d7d814        About an hour ago   742MB
nxtlytics/presto-docker-consul                 333-test                              32ee0b1b0738        5 days ago          1.94GB
```

Images can be found here: https://hub.docker.com/r/nxtlytics/presto-docker-consul/tags